### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,12 @@ jobs:
     steps:
       - run: exit 1
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard into the CI workflows to guard against malicious Go module downloads.

## Changes

- `.github/workflows/test.yaml` (`test` job calling go-test-full-workflow):
  - Bumped the reusable workflow ref `suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml` from `v5.0.2` (`e442a17816baa8a940edc1544cc6e739d870e165`) to `v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`).
  - Added a `secrets:` block passing `TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}`.
  - Added `id-token: write` to the job's `permissions:` (alongside the existing `pull-requests: write` and `contents: read`).

## Note

This bumps `go-test-full-workflow` across a MAJOR version (`v5` -> `v6`). Please review CI for any breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)